### PR TITLE
docs: remove stray build: bullet from latest CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v2.0.25
 
 - build(deps): bump alpine from 3.23 to 3.24
-- build: rename workflow_dispatch input labels for the GH UI
 - chore(deps): bump golang.org/x/net to v0.55.0 (CVE-2026-39821) (#242)
 
 ## v2.0.24


### PR DESCRIPTION
The auto-patch-release workflow added `- build: rename workflow_dispatch input labels for the GH UI` to the latest CHANGELOG entry. That bullet is a CI label rename with no runtime impact and shouldn't be user-facing.

A companion extension-kit PR adds `^build: ` to the default ignore regex so future runs skip such commits.