### PR TITLE
fix: guard nil route name/id when matching Kong routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: don't panic when matching Kong routes whose optional name (or id) is unset — `FindRoute` now nil-guards the comparisons (and the not-found error no longer dereferences an unset service name)
+
 ## v2.0.25
 
 - build(deps): bump alpine from 3.23 to 3.24

--- a/config/instance.go
+++ b/config/instance.go
@@ -100,12 +100,14 @@ func (i *Instance) FindRoute(service *kong.Service, nameOrId *string) (*kong.Rou
 	}
 	var routeFound *kong.Route
 	for _, route := range routes {
-		if *route.ID == *nameOrId || *route.Name == *nameOrId {
+		// Kong route Name is optional (and ID may be unset), so guard the dereferences.
+		if (route.ID != nil && *route.ID == *nameOrId) || (route.Name != nil && *route.Name == *nameOrId) {
 			routeFound = route
+			break
 		}
 	}
 	if routeFound == nil {
-		return nil, fmt.Errorf("the route %s does not belong to the service %s", *nameOrId, *service.Name)
+		return nil, fmt.Errorf("the route %s does not belong to the service %s", *nameOrId, kong.StringValue(service.Name))
 	}
 	return routeFound, nil
 }


### PR DESCRIPTION
## Problem (MAJOR — reachable panic)

`config/instance.go` `FindRoute` matched routes with:

```go
if *route.ID == *nameOrId || *route.Name == *nameOrId {
```

A Kong route's `Name` is **optional** (and `ID` may be unset), so a single unnamed route on the targeted service triggers a nil-pointer dereference panic in the route-level "Terminate Requests" action `Prepare`. The discovery path (`kong/route_discovery.go`) already guards `route.Name != nil`, confirming nil names are a real, expected state — so this handler was the unguarded gap.

## Fix

- Nil-guard both comparisons: `(route.ID != nil && *route.ID == *nameOrId) || (route.Name != nil && *route.Name == *nameOrId)`.
- `break` on the first match (the match is unique; the loop previously scanned all routes).
- The not-found error message no longer dereferences a possibly-unset `service.Name` (uses `kong.StringValue`).

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.

## /simplify
Scaled-down pass (2 agents) for this one-line-class change: reuse clean (the explicit `!= nil` guard matches the existing inline convention in `route_discovery.go`; no shared matcher warranted — `FindService`/`FindConsumer` resolve server-side). The altitude/simplification agent's two findings — add the `break`, and the sibling `*service.Name` deref — are both applied above.